### PR TITLE
add caching support

### DIFF
--- a/dir-index.cgi
+++ b/dir-index.cgi
@@ -13,6 +13,8 @@ use warnings;
 use Fcntl ':mode';
 use JSON;
 
+my $htmlcachedir = "/var/tmp/cgi-cache-test";
+
 my $stylecss = <<EOT;
   <style type="text/css">
   html, body {
@@ -201,7 +203,7 @@ sub printh1 {
 	$i ? htmlenc($parts[$i]) : '<em>(root)</em>';
   }
 
-  printf "<h1>Index of %s</h1>\n", $s;
+  printf "<h1>Index of test %s</h1>\n", $s;
 }
 
 sub print404 {
@@ -399,6 +401,18 @@ sub printdirectory {
 
 my $phys = $ENV{'DOCUMENT_ROOT'};
 my $virt = '/'.$ENV{'PATH_INFO'};
+
+# add caching function
+my $sanitized_virt = $virt;
+$sanitized_virt =~ s/\//_/g;
+my $htmlcachefile = $htmlcachedir."/".$sanitized_virt.".cache";
+#print "cachefile: ".$htmlcachefile."\n";
+if ( -e $htmlcachefile ) {
+    open(CACHE, "<$htmlcachefile") or die ("Unable to open $htmlcachefile due to $!\n");
+    my $html = <CACHE>;
+    print $html;
+    exit 0;
+}
 
 my @hidden = (                            # hide these files - never consider them
   qr!^/releases/\d\d\.\d\d-SNAPSHOT/?$!,

--- a/dir-index.cgi
+++ b/dir-index.cgi
@@ -205,18 +205,20 @@ sub printh1 {
 }
 
 sub print404 {
-  my $virt = shift;
-  print "Status: 404 Not found\n";
-  print "Content-type: text/html\n\n";
-  print "<!-- This directory index page generated on the fly by dir-index.cgi -->\n";
-  print "<html><head>\n";
-  print $stylecss;
-  printf "<title>Not found: %s</title></head>\n<body>\n", htmlenc($virt);
-  printf "<h1>Not found: %s</h1>\n", htmlenc($virt);
-  print "<hr>";
-  print "<p>The requested resource could not be found on the server.</p>";
-  print "<p>Try returning to the <a href=\"/\">root directory</a> to browse available directories.</p>";
-  print "</body></html>";
+    my $virt = shift;
+    my $html;
+    $html .= "Status: 404 Not found\n";
+    $html .= "Content-type: text/html\n\n";
+    $html .= "<!-- This directory index page generated on the fly by dir-index.cgi -->\n";
+    $html .= "<html><head>\n";
+    $html .= $stylecss;
+    $html .= "<title>Not found: %s</title></head>\n<body>\n", htmlenc($virt);
+    $html .= sprintf "<h1>Not found: %s</h1>\n", htmlenc($virt);
+    $html .= "<hr>";
+    $html .= "<p>The requested resource could not be found on the server.</p>";
+    $html .= "<p>Try returning to the <a href=\"/\">root directory</a> to browse available directories.</p>";
+    $html .= "</body></html>";
+    return $html;
 }
 
 sub printheader {


### PR DESCRIPTION
The on-the-fly generation of the package index pages is causing high load on the archive server. Update the script to support caching the generated HTML on the box.